### PR TITLE
7 verification email link does not work

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -67,15 +67,10 @@ class UserService:
             user_count = await cls.count(session)
             new_user.role = UserRole.ADMIN if user_count == 0 else UserRole.ANONYMOUS
             logger.info(f"User Role: {new_user.role}")
-            if new_user.role == UserRole.ADMIN:
-                new_user.email_verified = True
-
-            else:
-                new_user.verification_token = generate_verification_token()
-                await email_service.send_verification_email(new_user)
-
+            new_user.verification_token = generate_verification_token()
             session.add(new_user)
             await session.commit()
+            await email_service.send_verification_email(new_user)
             return new_user
         except ValidationError as e:
             logger.error(f"Validation error during user creation: {e}")
@@ -171,7 +166,8 @@ class UserService:
         if user and user.verification_token == token:
             user.email_verified = True
             user.verification_token = None  # Clear the token once used
-            user.role = UserRole.AUTHENTICATED
+            if user.role == UserRole.ANONYMOUS:
+                user.role = UserRole.AUTHENTICATED
             session.add(user)
             await session.commit()
             return True


### PR DESCRIPTION
It was found that the email was being sent before the user was committed to the DB which is when the UUID is generated. The email is now sent after being committed to the DB. Furthermore, admin users now have to verify their email before using the application. Unit tests were added to ensure that roles are updated correctly during verification and a manual test of the email link being populated with the correct URL with the UUID is was completed