### PR TITLE
12 peforming an update on a user that does not exist does not return a 404

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -86,8 +86,10 @@ async def update_user(user_id: UUID, user_update: UserUpdate, request: Request, 
     - **user_id**: UUID of the user to update.
     - **user_update**: UserUpdate model with updated user information.
     """
-    user_data = user_update.model_dump(exclude_unset=True)
     current_user_data = await UserService.get_by_id(db, user_id)
+    if not current_user_data:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    user_data = user_update.model_dump(exclude_unset=True)
     if 'email' in user_data:
         existing_user = await UserService.get_by_email(db, user_data["email"])
         if existing_user and existing_user.email != current_user_data.email:

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -1,4 +1,5 @@
 from builtins import str
+import uuid
 import pytest
 from httpx import AsyncClient
 from app.main import app
@@ -51,6 +52,12 @@ async def test_update_user_email_access_allowed(async_client, admin_user, admin_
     assert response.status_code == 200
     assert response.json()["email"] == updated_data["email"]
 
+@pytest.mark.asyncio
+async def test_update_invalid_uuid(async_client, admin_user, admin_token):
+    updated_data = {"email": f"updated_{admin_user.id}@example.com"}
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    response = await async_client.put(f"/users/{uuid.uuid4()}", json=updated_data, headers=headers)
+    assert response.status_code == 404
 
 @pytest.mark.asyncio
 async def test_delete_user(async_client, admin_user, admin_token):


### PR DESCRIPTION
The code I added to check for duplicate nicknames and emails before updating resulting a 404 error not being returned if the uuid did not exist. I added an if statement to check if the first get_by_id returns a user or not and now the update route returns 404 if a user was not found with the uuid.